### PR TITLE
new testsuite test for CS-1266 dbwriter handles custom usage values in accounting records

### DIFF
--- a/src/checktree_arco/checktree.tcl
+++ b/src/checktree_arco/checktree.tcl
@@ -80,6 +80,9 @@ proc arco_init_variables {} {
    set DBWRITER_LOG_FNAME "$ts_config(product_root)\/$ts_config(cell)\/spool\/dbwriter\/dbwriter.log"
 
    set ARCO_TABLES {}
+   if {[is_version_in_range "9.1.4"]} {
+      lappend ARCO_TABLES sge_job_usage_values
+   }
    lappend ARCO_TABLES sge_job_usage
    lappend ARCO_TABLES sge_job_log
    lappend ARCO_TABLES sge_job_request

--- a/src/checktree_arco/checktree/dbwriter/custom_usage/check.exp
+++ b/src/checktree_arco/checktree/dbwriter/custom_usage/check.exp
@@ -1,0 +1,235 @@
+#___INFO__MARK_BEGIN_NEW__
+###########################################################################
+#
+#  Copyright 2026 HPC-Gridware GmbH
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+###########################################################################
+#___INFO__MARK_END_NEW__
+
+# define global variable in this namespace
+global check_name
+global check_category
+global check_description
+global check_needs
+global check_functions
+global check_root_access_needs
+global check_version_range
+
+set check_version_range "9.1.4"
+
+# define test's name and run level descriptions
+set check_name            "dbwriter_custom_usage"
+set check_category        "DBWRITER JOB_SYNC VERIFIED"
+set check_description(0)  "verify custom usage values from acct records land in sge_job_usage_values (CS-1266)"
+
+# define test's dependencies
+set check_needs           "init_core_system arco_database_install arco_dbwriter_install"
+
+# setup and cleanup functions
+set check_setup_function dbwriter_custom_usage_setup
+set check_cleanup_function dbwriter_custom_usage_cleanup
+
+# define test's procedure order
+set check_functions {}
+lappend check_functions "dbwriter_custom_usage_numeric_test"
+
+# -------- local test procedures: initialization------------------------------
+
+proc dbwriter_custom_usage_setup {} {
+   get_current_cluster_config_array ts_config
+   global CHECK_ACTUAL_TEST_PATH
+   global dbwriter_custom_usage_backup
+
+   # backup the global config so cleanup can restore
+   get_config dbwriter_custom_usage_backup
+
+   # enable reporting + set usage_patterns to whitelist the test variables
+   set delimiter " "
+   add_or_replace_array_param new_conf dbwriter_custom_usage_backup reporting_params "reporting" "true" $delimiter
+   add_or_replace_array_param new_conf new_conf reporting_params "usage_patterns" "custom:custom_*" $delimiter
+   add_or_replace_array_param new_conf new_conf reporting_params "flush_time" "00:00:01" $delimiter
+   set_config new_conf
+
+   # create a dedicated test queue on @allhosts with the custom-usage epilog
+   # attached. Isolates the test from all.q; the epilog script ships alongside
+   # this check.exp (cs1266_custom_usage_epilog.sh) so it lives at the same
+   # test-tree location on every cluster host — no runtime NFS-write race.
+   set queue_conf(epilog) "$CHECK_ACTUAL_TEST_PATH/cs1266_custom_usage_epilog.sh"
+   add_queue "test.q" "@allhosts" queue_conf
+
+   # start dbwriter if it isn't already running
+   if {[get_dbwriter_status 0] != 0} {
+      ts_log_fine "starting dbwriter"
+      if {[startup_dbwriter] != 0} {
+         ts_log_config "could not start dbwriter"
+         return 99
+      }
+   }
+   wait_for_enter
+}
+
+proc dbwriter_custom_usage_cleanup {} {
+   get_current_cluster_config_array ts_config
+   global dbwriter_custom_usage_backup
+
+   ts_log_fine "shutting down dbwriter"
+   shutdown_dbwriter
+
+   delete_all_jobs
+   wait_for_end_of_all_jobs
+
+   # remove the dedicated test queue and restore global config
+   del_queue "test.q" "@allhosts" 0 1
+   reset_config dbwriter_custom_usage_backup
+
+   unset -nocomplain dbwriter_custom_usage_backup
+wait_for_enter
+   # clean data from arco database
+   arco_clean_database
+}
+
+# helper: run a single SQL query via sqlutil and return the result rows.
+# Returns a list of row-dicts (each a flat list of key/value pairs) or {} on
+# no results. Uses sqlutil_query's array-based API; expects sp_id from an
+# already-connected sqlutil process.
+proc dbwriter_custom_usage_query {sp_id sql} {
+   array set result_array {}
+   set column_names {}
+   set res [sqlutil_query $sp_id "$sql" result_array column_names]
+   if {$res < 0} {
+      ts_log_severe "sqlutil_query failed for: $sql"
+      return {}
+   }
+   set rows {}
+   for {set i 0} {$i < $res} {incr i} {
+      set row_dict {}
+      set col 0
+      foreach col_name $column_names {
+         lappend row_dict $col_name $result_array($i,$col)
+         incr col
+      }
+      lappend rows $row_dict
+   }
+   return $rows
+}
+
+# submit a short-running job, wait for it to finish and for dbwriter to
+# ingest its acct record, then query sge_job_usage_values and assert:
+# - two rows exist for that job's ju_id (custom_foo and custom_bar)
+# - each row has juv_dvalue populated with the expected value
+# - each row has juv_svalue NULL (XOR-invariant regression guard against
+#   an implementer accidentally mirroring HostValueManager's dual-column
+#   write pattern; see plan finding 2)
+proc dbwriter_custom_usage_numeric_test {} {
+   get_current_cluster_config_array ts_config
+   global CHECK_USER
+
+   ts_log_fine "submitting a sleep job that will trigger the custom_usage epilog"
+   set job_id [submit_job "-sync y -q test.q $ts_config(product_root)/examples/jobs/sleeper.sh 5"]
+   if {$job_id <= 0} {
+      ts_log_severe "could not submit test job"
+      return
+   }
+
+   # wait for the job to end (submitted with -sync y so submit_job returns
+   # only after the job finishes; be defensive anyway)
+   wait_for_end_of_all_jobs 60
+
+   after 1000
+   ts_log_fine [start_remote_prog $ts_config(master_host) $CHECK_USER "cat" "$ts_config(product_root)/$ts_config(cell)/common/reporting.jsonl"]
+
+   # connect to arco database
+   ts_log_fine "connecting to arco database"
+   set id [sqlutil_create]
+   if {$id == "-1"} {
+      ts_log_severe "sqlutil_create failed"
+      return
+   }
+   set sp_id [lindex $id 1]
+   if {[sqlutil_connect $sp_id] != 0} {
+      ts_log_severe "could not connect to arco database"
+      close_spawn_process $id
+      return
+   }
+
+   # poll until dbwriter ingests both custom-usage rows (up to 60s)
+   set sql "SELECT juv.juv_variable, juv.juv_svalue, juv.juv_dvalue"
+   append sql " FROM sge_job j, sge_job_usage ju, sge_job_usage_values juv"
+   append sql " WHERE j.j_id = ju.ju_parent AND ju.ju_id = juv.juv_parent"
+   append sql " AND j.j_job_number = $job_id"
+   append sql " ORDER BY juv.juv_variable"
+
+   set found 0
+   set rows {}
+   for {set try 0} {$try < 12} {incr try} {
+      set rows [dbwriter_custom_usage_query $sp_id $sql]
+      if {[llength $rows] >= 2} {
+         set found 1
+         break
+      }
+      sleep_for_seconds 5
+   }
+   if {!$found} {
+      ts_log_severe "expected 2 sge_job_usage_values rows for job $job_id, got [llength $rows] after 60s poll"
+      close_spawn_process $id
+      return
+   }
+
+   # verify per-variable values (custom_bar first alphabetically, custom_foo second)
+   set expected {custom_bar 7.5 custom_foo 42}
+   foreach row $rows {
+      array set row_a $row
+      set name $row_a(juv_variable)
+      set svalue $row_a(juv_svalue)
+      set dvalue $row_a(juv_dvalue)
+
+      # XOR invariant: juv_svalue must be NULL for numeric-only CS-1266 phase.
+      # sqlutil renders SQL NULL as the literal string "null" (lowercase) or "NULL";
+      # accept both, plus empty string for defensive-string cases.
+      if {$svalue ne "" && [string tolower $svalue] ne "null"} {
+         ts_log_severe "XOR invariant violated: juv_variable=$name has juv_svalue='$svalue' (expected NULL) — see plan U2/U4"
+      }
+
+      # verify dvalue matches expected
+      if {![info exists row_a(juv_dvalue)] || $dvalue eq ""} {
+         ts_log_severe "juv_variable=$name has no juv_dvalue"
+         continue
+      }
+      if {$name eq "custom_foo"} {
+         if {[expr abs($dvalue - 42)] > 0.001} {
+            ts_log_severe "juv_variable=custom_foo has juv_dvalue=$dvalue (expected 42)"
+         }
+      } elseif {$name eq "custom_bar"} {
+         if {[expr abs($dvalue - 7.5)] > 0.001} {
+            ts_log_severe "juv_variable=custom_bar has juv_dvalue=$dvalue (expected 7.5)"
+         }
+      } else {
+         ts_log_info "unexpected juv_variable=$name (dvalue=$dvalue) — test only whitelisted custom_foo and custom_bar"
+      }
+      array unset row_a
+   }
+
+   # aggregate XOR regression guard across the whole test (finding-2 assertion)
+   set aggregate_sql "SELECT COUNT(*) AS n FROM sge_job_usage_values WHERE juv_svalue IS NOT NULL"
+   set agg_rows [dbwriter_custom_usage_query $sp_id $aggregate_sql]
+   if {[llength $agg_rows] > 0} {
+      array set agg [lindex $agg_rows 0]
+      if {$agg(n) != 0} {
+         ts_log_severe "XOR-invariant regression: $agg(n) rows have non-NULL juv_svalue in the numeric-only CS-1266 phase"
+      }
+   }
+
+   close_spawn_process $id
+}

--- a/src/checktree_arco/checktree/dbwriter/custom_usage/cs1266_custom_usage_epilog.sh
+++ b/src/checktree_arco/checktree/dbwriter/custom_usage/cs1266_custom_usage_epilog.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Epilog script for the checktree_arco/dbwriter/custom_usage TCL test (CS-1266).
+# Appends two custom usage values to the shepherd usage file. sge_execd
+# reads these on job exit and includes them in the acct record; dbwriter's
+# JSONL parser then routes them into sge_job_usage_values.
+#
+# SGE_JOB_SPOOL_DIR is set by the shepherd for prolog/epilog execution and
+# is the per-job spool directory the shepherd is currently using.
+#
+
+echo "custom_foo=42" >> "$SGE_JOB_SPOOL_DIR/usage"
+echo "custom_bar=7.5" >> "$SGE_JOB_SPOOL_DIR/usage"
+exit 0


### PR DESCRIPTION
Adds testsuite/src/checktree_arco/checktree/dbwriter/custom_usage/check.exp plus its ships-alongside epilog script cs1266_custom_usage_epilog.sh. The check submits a sleeper job into a dedicated test.q on @allhosts whose epilog appends custom_foo=42 and custom_bar=7.5 to the shepherd usage file, then polls sge_job_usage_values via sqlutil until dbwriter ingests both rows. Per-row check asserts juv_dvalue matches the expected values and juv_svalue renders as NULL; an aggregate

    SELECT COUNT(*) FROM sge_job_usage_values WHERE juv_svalue IS NOT NULL

== 0 acts as the XOR-invariant regression guard (catches implementers mirroring HostValueManager's dual-column write pattern, or forgetting the nullable-field-type mechanism the dbwriter side ships).

The epilog script ships next to check.exp and is referenced via $CHECK_ACTUAL_TEST_PATH so every cluster host reads the same committed bytes -- avoids the NFS-write-visibility race a runtime TCL open/puts/ close would hit. The test uses a dedicated test.q on @allhosts (via add_queue), never touches all.q.

Also extends arco_init_variables in checktree_arco/checktree.tcl to include sge_job_usage_values in ARCO_TABLES (version-gated on 9.1.4, placed before sge_job_usage so the child-before-parent cleanup order the surrounding entries use holds for FK-safe database teardown).