### PR TITLE
BF: CS-2425 remove legacy check_init_level_procedure driver line

### DIFF
--- a/src/check.exp
+++ b/src/check.exp
@@ -3806,7 +3806,6 @@ proc delete_tests {path state_to_delete {only_if_not_there 0}} {
    foreach elem $selected_tests {
       set check_highest_level 0
       set check_name ""
-      set check_init_level_procedure "--"
       unset -nocomplain check_version_range
 
       # sourcing the test modules sets the global variables check_name and check_needs


### PR DESCRIPTION
CS-136 removed the init_level callback from the test dispatcher. The per-check-loop initializer in delete_tests still primed the variable to "--" for each test being inspected, keeping a name-only reference to a concept that no longer exists. Drop the line; delete_tests no longer touches the variable, matching how run_tests already works.